### PR TITLE
escape sequence error fix

### DIFF
--- a/proscheduler.py
+++ b/proscheduler.py
@@ -11,7 +11,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support import expected_conditions as EC
 
-prometric_logo = """
+prometric_logo = r"""
 
  ____                           _        _      
 |  _ \ _ __ ___  _ __ ___   ___| |_ _ __(_) ___ 


### PR DESCRIPTION
fixed: SyntaxWarning: invalid escape sequence '\ '
in prometric logo string
fixed by using raw string